### PR TITLE
Add schedule `Chrome` weekly check

### DIFF
--- a/.github/workflows/check-new-ver.yml
+++ b/.github/workflows/check-new-ver.yml
@@ -1,9 +1,11 @@
+name: Check new version
+
 on:
   schedule:
-    - cron:  '30 5 * * 1'
+    - cron: "30 5 * * 1"
 
 jobs:
-  check-chrome:
+  check:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/check-new-ver.yml
+++ b/.github/workflows/check-new-ver.yml
@@ -10,73 +10,16 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Parse current version
-        run: |
-          grep 'WEBRTC_VERSION' ./VERSION |
-          cut -d'=' -f2 |
-          {
-            read version;
-            echo "CURRENT_VERSION=${version}" >> $GITHUB_ENV;
-          }
-
-      - name: Get last stable version and hash
-        uses: actions/github-script@v6
-        id: webrtc-commit
-        with:
-          script: |
-            const https = require('https');
-
-            await new Promise(resolve => {
-              https.get('https://chromiumdash.appspot.com/fetch_releases?channel=Stable&platform=Linux&num=1&offset=0', (resp) => {
-                let data = '';
-
-                resp.on('data', (chunk) => {
-                  data += chunk;
-                });
-
-                resp.on('end', () => {
-                  resolve(data);
-                });
-
-              })
-            }).then(data => {
-                const commit = JSON.parse(data)[0];
-                core.exportVariable('LAST_VERSION', commit.version);
-                core.exportVariable('WEBRTC_HASH', commit.hashes.webrtc);
-              });
-
-      - name: Check if the versions are different
-        run: |
-          if [ $LAST_VERSION = $CURRENT_VERSION ]
-          then
-            echo "The latest version ($CURRENT_VERSION) is already released!"
-            exit 1
-          fi
-          echo "There is a new version!"
-
       - name: Patch ./VERSION
-        run: |
-          grep -n 'WEBRTC_VERSION' ./VERSION |
-          cut -d':' -f1 |
-          {
-            read line;
-            sed -i "${line}s|.*|WEBRTC_VERSION=${LAST_VERSION}|g" ./VERSION;
-          }
-
-          grep -n 'WEBRTC_COMMIT' ./VERSION |
-          cut -d':' -f1 |
-          {
-            read line;
-            sed -i "${line}s|.*|WEBRTC_COMMIT=${WEBRTC_HASH}|g" ./VERSION;
-          }
+        run: ./upgrade-ver.sh
 
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v4
         with:
           token: ${{ secrets.GH_INSTRUMENTISTO_BOT_PAT }}
-          commit-message: Upgrade to ${{ env.LAST_VERSION }} version
-          branch: upgrade-to-${{ env.LAST_VERSION }}
-          title: Upgrade to ${{ env.LAST_VERSION }}
-          body: Upgrade libwebrtc version to ${{ env.LAST_VERSION }}.
+          commit-message: Upgrade to ${{ steps.patch_ver.outputs.version }} version
+          branch: upgrade-to-${{ steps.patch_ver.outputs.version }}
+          title: Upgrade to ${{ steps.patch_ver.outputs.version }}
+          body: Upgrade libwebrtc version to ${{ steps.patch_ver.outputs.version }}.
           labels: k::version
           delete-branch: true

--- a/.github/workflows/check-new-ver.yml
+++ b/.github/workflows/check-new-ver.yml
@@ -10,17 +10,18 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Patch ./VERSION
-        id: patch_ver
-        run: ./upgrade-ver.sh
+      - run: ./upgrade-ver.sh
+        id: patch
 
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v4
         with:
-          token: ${{ secrets.GH_INSTRUMENTISTO_BOT_PAT }}
-          commit-message: Upgrade to ${{ steps.patch_ver.outputs.version }} version
-          branch: upgrade-to-${{ steps.patch_ver.outputs.version }}
-          title: Upgrade to ${{ steps.patch_ver.outputs.version }}
-          body: Upgrade libwebrtc version to ${{ steps.patch_ver.outputs.version }}.
-          labels: k::version
+          commit-message: Upgrade to ${{ steps.patch.outputs.version }} version
+          branch: upgrade-to-${{ steps.patch.outputs.version }}
           delete-branch: true
+          title: Upgrade to ${{ steps.patch.outputs.version }}
+          body: Upgrade `libwebrtc` version to ${{ steps.patch.outputs.version }}.
+          labels: |
+            enhancement
+            k::version
+          token: ${{ secrets.GH_INSTRUMENTISTO_BOT_PAT }}

--- a/.github/workflows/check-new-ver.yml
+++ b/.github/workflows/check-new-ver.yml
@@ -11,16 +11,16 @@ jobs:
       - uses: actions/checkout@v3
 
       - run: ./upgrade-ver.sh
-        id: patch
+        id: new
 
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v4
         with:
-          commit-message: Upgrade to ${{ steps.patch.outputs.version }} version
-          branch: upgrade-to-${{ steps.patch.outputs.version }}
+          commit-message: Upgrade to ${{ steps.new.outputs.version }} version
+          branch: upgrade-to-${{ steps.new.outputs.version }}
           delete-branch: true
-          title: Upgrade to ${{ steps.patch.outputs.version }}
-          body: Upgrade `libwebrtc` version to ${{ steps.patch.outputs.version }}.
+          title: Upgrade to ${{ steps.new.outputs.version }}
+          body: Upgrade `libwebrtc` version to ${{ steps.new.outputs.version }}.
           labels: |
             enhancement
             k::version

--- a/.github/workflows/check-new-ver.yml
+++ b/.github/workflows/check-new-ver.yml
@@ -11,6 +11,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Patch ./VERSION
+        id: patch_ver
         run: ./upgrade-ver.sh
 
       - name: Create Pull Request

--- a/.github/workflows/chrome-check.yml
+++ b/.github/workflows/chrome-check.yml
@@ -1,4 +1,4 @@
-on: 
+on:
   schedule:
     - cron:  '30 5 * * 1'
 
@@ -72,7 +72,6 @@ jobs:
         uses: peter-evans/create-pull-request@v4
         with:
           token: ${{ secrets.GH_INSTRUMENTISTO_BOT_PAT }}
-          committer: GitHub <noreply@github.com>
           commit-message: Upgrade to ${{ env.LAST_VERSION }} version
           branch: upgrade-to-${{ env.LAST_VERSION }}
           title: Upgrade to ${{ env.LAST_VERSION }}

--- a/.github/workflows/chrome-check.yml
+++ b/.github/workflows/chrome-check.yml
@@ -71,7 +71,7 @@ jobs:
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v4
         with:
-          token: ${{ secrets.PAT }}
+          token: ${{ secrets.GH_INSTRUMENTISTO_BOT_PAT }}
           committer: GitHub <noreply@github.com>
           commit-message: Upgrade to ${{ env.LAST_VERSION }} version
           branch: upgrade-to-${{ env.LAST_VERSION }}

--- a/.github/workflows/chrome-check.yml
+++ b/.github/workflows/chrome-check.yml
@@ -1,0 +1,81 @@
+on: 
+  schedule:
+    - cron:  '30 5 * * 1'
+
+jobs:
+  check-chrome:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Parse current version
+        run: |
+          grep 'WEBRTC_VERSION' ./VERSION |
+          cut -d'=' -f2 |
+          {
+            read version;
+            echo "CURRENT_VERSION=${version}" >> $GITHUB_ENV;
+          }
+
+      - name: Get last stable version and hash
+        uses: actions/github-script@v6
+        id: webrtc-commit
+        with:
+          script: |
+            const https = require('https');
+
+            await new Promise(resolve => {
+              https.get('https://chromiumdash.appspot.com/fetch_releases?channel=Stable&platform=Linux&num=1&offset=0', (resp) => {
+                let data = '';
+
+                resp.on('data', (chunk) => {
+                  data += chunk;
+                });
+
+                resp.on('end', () => {
+                  resolve(data);
+                });
+
+              })
+            }).then(data => {
+                const commit = JSON.parse(data)[0];
+                core.exportVariable('LAST_VERSION', commit.version);
+                core.exportVariable('WEBRTC_HASH', commit.hashes.webrtc);
+              });
+
+      - name: Check if the versions are different
+        run: |
+          if [ $LAST_VERSION = $CURRENT_VERSION ]
+          then
+            echo "The latest version ($CURRENT_VERSION) is already released!"
+            exit 1
+          fi
+          echo "There is a new version!"
+
+      - name: Patch ./VERSION
+        run: |
+          grep -n 'WEBRTC_VERSION' ./VERSION |
+          cut -d':' -f1 |
+          {
+            read line;
+            sed -i "${line}s|.*|WEBRTC_VERSION=${LAST_VERSION}|g" ./VERSION;
+          }
+
+          grep -n 'WEBRTC_COMMIT' ./VERSION |
+          cut -d':' -f1 |
+          {
+            read line;
+            sed -i "${line}s|.*|WEBRTC_COMMIT=${WEBRTC_HASH}|g" ./VERSION;
+          }
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v4
+        with:
+          token: ${{ secrets.PAT }}
+          committer: GitHub <noreply@github.com>
+          commit-message: Upgrade to ${{ env.LAST_VERSION }} version
+          branch: upgrade-to-${{ env.LAST_VERSION }}
+          title: Upgrade to ${{ env.LAST_VERSION }}
+          body: Upgrade libwebrtc version to ${{ env.LAST_VERSION }}.
+          labels: k::version
+          delete-branch: true

--- a/.gitignore
+++ b/.gitignore
@@ -120,3 +120,4 @@ webrtc/
 webrtc-cache/
 webrtc_build/
 
+/VERSION.bk

--- a/upgrade-ver.sh
+++ b/upgrade-ver.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+curl 'https://chromiumdash.appspot.com/fetch_releases?channel=Stable&platform=Linux&num=1&offset=0' |
+sed 's/,/\n/g' | 
+sed 's/["|\}|\{|\[]//g' |
+sed 's/]//g' |
+grep '^version\|^webrtc' |
+while read p; do
+    name=$(echo "$p" | cut -d':' -f1)
+    value=$(echo "$p" | cut -d':' -f2)
+    field=$([[ $name = version ]] && echo "WEBRTC_VERSION" || echo "WEBRTC_COMMIT")
+    grep -n $field ./VERSION |
+    cut -d':' -f1 |
+    {
+        read line;
+        sed -i "${line}s|.*|${field}=${value}|g" ./VERSION;
+    }
+    if [ $name = version ]
+    then
+        echo "::set-output name=$(echo $name)::$(echo $value)"
+    fi
+done

--- a/upgrade-ver.sh
+++ b/upgrade-ver.sh
@@ -10,10 +10,7 @@ if [[ "$res" != *"\"webrtc\""* ]]; then
     exit 1
 fi
 echo "$res" |
-sed 's/,/\n/g' |
-sed 's/["|\}|\{|\[]//g' |
-sed 's/]//g' |
-grep '^version\|^webrtc' |
+jq -r '"version:\(.[0].version)\nwebrtc:\(.[0].hashes.webrtc)"' |
 while read data; do
     name=$(echo "$data" | cut -d':' -f1)
     value=$(echo "$data" | cut -d':' -f2)

--- a/upgrade-ver.sh
+++ b/upgrade-ver.sh
@@ -16,8 +16,9 @@ if [[ "$newCommit" = "null" ]]; then
   exit 1
 fi
 
-sed -i.bk "s/^WEBRTC_VERSION=.*$/WEBRTC_VERSION=$newVersion/g" ./VERSION
-sed -i.bk "s/^WEBRTC_COMMIT=.*$/WEBRTC_COMMIT=$newCommit/g" ./VERSION
+sed -i.bk -e "s/^WEBRTC_VERSION=.*$/WEBRTC_VERSION=$newVersion/g" \
+          -e "s/^WEBRTC_COMMIT=.*$/WEBRTC_COMMIT=$newCommit/g" \
+    ./VERSION
 
 echo "::set-output name=version::$newVersion"
 echo "::set-output name=commit::$newCommit"

--- a/upgrade-ver.sh
+++ b/upgrade-ver.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 res=$(curl 'https://chromiumdash.appspot.com/fetch_releases?channel=Stable&platform=Linux&num=1&offset=0')
-if [[ "$res" != *"\"verssion\""* ]]; then
+if [[ "$res" != *"\"version\""* ]]; then
     echo -e "There is wrong \`JSON\` response, no \`version\` field there.\nCheck the \`Chrome API\`, fix this \`.sh\` if needed and/or try again."
     exit 1
 fi

--- a/upgrade-ver.sh
+++ b/upgrade-ver.sh
@@ -1,27 +1,23 @@
-#!/bin/bash
+#!/usr/bin/env bash
+
+set -e
 
 res=$(curl 'https://chromiumdash.appspot.com/fetch_releases?channel=Stable&platform=Linux&num=1&offset=0')
-if [[ "$res" != *"\"version\""* ]]; then
-    echo -e "There is wrong \`JSON\` response, no \`version\` field there.\nCheck the \`Chrome API\`, fix this \`.sh\` if needed and/or try again."
-    exit 1
+
+newVersion=$(printf "$res" | jq -r '.[0].version')
+if [[ "$newVersion" = "null" ]]; then
+  echo -e "Wrong JSON response, no \`version\` field found.\nCheck the Chrome API and fix this \`.sh\` if needed and/or try again."
+  exit 1
 fi
-if [[ "$res" != *"\"webrtc\""* ]]; then
-    echo -e "There is wrong \`JSON\` response, no \`webrtc\` field there.\nCheck the \`Chrome API\`, fix this \`.sh\` if needed and/or try again."
-    exit 1
+
+newCommit=$(printf "$res" | jq -r '.[0].hashes.webrtc')
+if [[ "$newCommit" = "null" ]]; then
+  echo -e "Wrong JSON response, no \`hashes.webrtc\` field found.\nCheck the Chrome API and fix this \`.sh\` if needed and/or try again."
+  exit 1
 fi
-echo "$res" |
-jq -r '"version:\(.[0].version)\nwebrtc:\(.[0].hashes.webrtc)"' |
-while read data; do
-    name=$(echo "$data" | cut -d':' -f1)
-    value=$(echo "$data" | cut -d':' -f2)
-    field=$([[ $name = version ]] && echo "WEBRTC_VERSION" || echo "WEBRTC_COMMIT")
-    grep -n $field ./VERSION |
-    cut -d':' -f1 |
-    {
-        read line
-        sed -i "${line}s|.*|${field}=${value}|g" ./VERSION
-    }
-    if [ $name = version ]; then
-        echo "::set-output name=$(echo $name)::$(echo $value)"
-    fi
-done
+
+sed -i.bk "s/^WEBRTC_VERSION=.*$/WEBRTC_VERSION=$newVersion/g" ./VERSION
+sed -i.bk "s/^WEBRTC_COMMIT=.*$/WEBRTC_COMMIT=$newCommit/g" ./VERSION
+
+echo "::set-output name=version::$newVersion"
+echo "::set-output name=commit::$newCommit"

--- a/upgrade-ver.sh
+++ b/upgrade-ver.sh
@@ -1,22 +1,30 @@
 #!/bin/bash
 
-curl 'https://chromiumdash.appspot.com/fetch_releases?channel=Stable&platform=Linux&num=1&offset=0' |
-sed 's/,/\n/g' | 
+res=$(curl 'https://chromiumdash.appspot.com/fetch_releases?channel=Stable&platform=Linux&num=1&offset=0')
+if [[ "$res" != *"\"verssion\""* ]]; then
+    echo -e "There is wrong \`JSON\` response, no \`version\` field there.\nCheck the \`Chrome API\`, fix this \`.sh\` if needed and/or try again."
+    exit 1
+fi
+if [[ "$res" != *"\"webrtc\""* ]]; then
+    echo -e "There is wrong \`JSON\` response, no \`webrtc\` field there.\nCheck the \`Chrome API\`, fix this \`.sh\` if needed and/or try again."
+    exit 1
+fi
+echo "$res" |
+sed 's/,/\n/g' |
 sed 's/["|\}|\{|\[]//g' |
 sed 's/]//g' |
 grep '^version\|^webrtc' |
-while read p; do
-    name=$(echo "$p" | cut -d':' -f1)
-    value=$(echo "$p" | cut -d':' -f2)
+while read data; do
+    name=$(echo "$data" | cut -d':' -f1)
+    value=$(echo "$data" | cut -d':' -f2)
     field=$([[ $name = version ]] && echo "WEBRTC_VERSION" || echo "WEBRTC_COMMIT")
     grep -n $field ./VERSION |
     cut -d':' -f1 |
     {
-        read line;
-        sed -i "${line}s|.*|${field}=${value}|g" ./VERSION;
+        read line
+        sed -i "${line}s|.*|${field}=${value}|g" ./VERSION
     }
-    if [ $name = version ]
-    then
+    if [ $name = version ]; then
         echo "::set-output name=$(echo $name)::$(echo $value)"
     fi
 done


### PR DESCRIPTION
## Synopsis

This PR adds a new schedule workflow for checking the last stable version of the Chrome and creates a new automate PR with updated `version` and `commit`.


## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains `Draft: ` prefix
    - [x] Name contains issue reference
    - [x] Has `k::` labels applied
    - [x] Has assignee
- [x] Documentation is updated (if required)
- [x] Tests are updated (if required)
- [x] Changes conform code style
- [x] CHANGELOG entry is added (if required)
- [x] FCM (final commit message) is posted
    - [x] and approved
- [x] [Review][l:2] is completed and changes are approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] `Draft: ` prefix is removed
    - [x] All temporary labels are removed





[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests