### PR TITLE
Delete c++ launder

### DIFF
--- a/build/common.mk
+++ b/build/common.mk
@@ -36,6 +36,7 @@ common-patch:
 	&& patch -p1 < $(PATCH_DIR)/nacl_armv6_2.patch \
 	&& patch -p2 < $(PATCH_DIR)/macos_h264_encoder.patch \
 	&& patch -p2 < $(PATCH_DIR)/disable_use_hermetic_xcode_on_linux.patch \
+	&& patch -p2 < $(PATCH_DIR)/linux_fix_launder.patch \
 	&& patch -p2 < $(PATCH_DIR)/add_licenses.patch
 
 .PHONY: common-package

--- a/patch/linux_fix_launder.patch
+++ b/patch/linux_fix_launder.patch
@@ -1,0 +1,17 @@
+diff --git a/src/third_party/abseil-cpp/absl/functional/internal/any_invocable.h b/src/third_party/abseil-cpp/absl/functional/internal/any_invocable.h
+index f353139..0e046b7 100644
+--- a/src/third_party/abseil-cpp/absl/functional/internal/any_invocable.h
++++ b/src/third_party/abseil-cpp/absl/functional/internal/any_invocable.h
+@@ -195,11 +195,7 @@ union TypeErasedState {
+ template <class T>
+ T& ObjectInLocalStorage(TypeErasedState* const state) {
+   // We launder here because the storage may be reused with the same type.
+-#if ABSL_INTERNAL_CPLUSPLUS_LANG >= 201703L
+-  return *std::launder(reinterpret_cast<T*>(&state->storage));
+-#elif ABSL_HAVE_BUILTIN(__builtin_launder)
+   return *__builtin_launder(reinterpret_cast<T*>(&state->storage));
+-#else
+ 
+   // When `std::launder` or equivalent are not available, we rely on undefined
+   // behavior, which works as intended on Abseil's officially supported
+


### PR DESCRIPTION
## Synopsis

This PR delete `std::launder` from `any_invocable.h` for uses lib with old GLIBCXX.

## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains `Draft: ` prefix
    - [x] Name contains issue reference
    - [x] Has `k::` labels applied
    - [x] Has assignee
- [ ] Documentation is updated (if required)
- [ ] Tests are updated (if required)
- [ ] Changes conform code style
- [ ] CHANGELOG entry is added (if required)
- [ ] FCM (final commit message) is posted
    - [ ] and approved
- [ ] [Review][l:2] is completed and changes are approved
- Before merge:
    - [ ] Milestone is set
    - [ ] PR's name and description are correct and up-to-date
    - [ ] `Draft: ` prefix is removed
    - [ ] All temporary labels are removed





[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests