### PR TITLE
MacOS capture device discovery support for old systems

### DIFF
--- a/build/macos-arm64/Makefile
+++ b/build/macos-arm64/Makefile
@@ -47,6 +47,8 @@ copy: common-copy
 
 .PHONY: patch
 patch: common-patch
+	cd $(SRC_DIR) && \
+	patch -p2 < $(PATCH_DIR)/capture_device_support_on_old_macos.patch
 
 .PHONY: build
 build: patch

--- a/build/macos-x64/Makefile
+++ b/build/macos-x64/Makefile
@@ -47,6 +47,8 @@ copy: common-copy
 
 .PHONY: patch
 patch: common-patch
+	cd $(SRC_DIR) && \
+	patch -p2 < $(PATCH_DIR)/capture_device_support_on_old_macos.patch
 
 .PHONY: build
 build: patch

--- a/patch/capture_device_support_on_old_macos.patch
+++ b/patch/capture_device_support_on_old_macos.patch
@@ -1,0 +1,23 @@
+--- a/src/sdk/objc/components/capturer/RTCCameraVideoCapturer.m
++++ b/src/sdk/objc/components/capturer/RTCCameraVideoCapturer.m
+@@ -118,11 +118,15 @@ - (void)dealloc {
+ }
+
+ + (NSArray<AVCaptureDevice *> *)captureDevices {
+-  AVCaptureDeviceDiscoverySession *session = [AVCaptureDeviceDiscoverySession
+-      discoverySessionWithDeviceTypes:@[ AVCaptureDeviceTypeBuiltInWideAngleCamera ]
+-                            mediaType:AVMediaTypeVideo
+-                             position:AVCaptureDevicePositionUnspecified];
+-  return session.devices;
++  if (@available(macOS 10.15, *)) {
++    AVCaptureDeviceDiscoverySession *session = [AVCaptureDeviceDiscoverySession
++        discoverySessionWithDeviceTypes:@[ AVCaptureDeviceTypeBuiltInWideAngleCamera ]
++                              mediaType:AVMediaTypeVideo
++                              position:AVCaptureDevicePositionUnspecified];
++    return session.devices;
++  } else {
++    return [AVCaptureDevice devicesWithMediaType:AVMediaTypeVideo];
++  }
+ }
+
+ + (NSArray<AVCaptureDeviceFormat *> *)supportedFormatsForDevice:(AVCaptureDevice *)device {


### PR DESCRIPTION
## Synopsis

While fixing instrumentisto/flutter-webrtc#147 it was discovered that `libwebrtc` also uses new MacOS API which crashes application on old MacOS systems. So we need to fix this here too.




## Solution

Add a patch which works similarly to the approach used in the `instrumentisto/flutter-webrtc`. In other words just use old API on old systems and new API on new systems.




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
    - [x] Has assignee
- Before [review][l:4]:
    - [x] Documentation is updated (if required)
    - [x] Tests are updated (if required)
    - [x] Changes conform [code style][l:2]
    - [x] [CHANGELOG entry][l:3] is added (if required)
    - [x] FCM (final commit message) is posted or updated
    - [ ] [Draft mode][l:1] is removed
- [ ] [Review][l:4] is completed and changes are approved
    - [ ] FCM (final commit message) is approved
- Before merge:
    - [ ] Milestone is set
    - [ ] PR's name and description are correct and up-to-date
    - [ ] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: /CONTRIBUTING.md#code-style
[l:3]: /CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests