### PR TITLE
Fix `[[deprecated]]` attribute usage

### DIFF
--- a/build.windows.ps1
+++ b/build.windows.ps1
@@ -117,6 +117,7 @@ Exec { gclient sync --with_branch_heads -r $WEBRTC_COMMIT }
 Exec { git apply --ignore-space-change -v $PATCH_DIR\add_licenses.patch }
 Exec { git apply --ignore-space-change -v $PATCH_DIR\4k.patch }
 Exec { git apply --ignore-space-change -v $PATCH_DIR\webrtc_voice_engine.patch }
+Exec { git apply --ignore-space-change -v $PATCH_DIR\fix_deprecated.patch }
 Exec { git apply --ignore-space-change -v $PATCH_DIR\win_dynamic_crt.patch }
 Exec { git apply --ignore-space-change -v $PATCH_DIR\windows_fix_abseil.patch }
 Pop-Location

--- a/build/common.mk
+++ b/build/common.mk
@@ -34,6 +34,7 @@ common-patch:
 	echo "apply patches ..." \
 	&& cd $(SRC_DIR) \
 	&& patch -p1 < $(PATCH_DIR)/nacl_armv6_2.patch \
+	&& patch -p2 < $(PATCH_DIR)/fix_deprecated.patch \
 	&& patch -p2 < $(PATCH_DIR)/add_licenses.patch \
 	&& patch -p2 < $(PATCH_DIR)/4k.patch
 

--- a/patch/fix_deprecated.patch
+++ b/patch/fix_deprecated.patch
@@ -1,0 +1,26 @@
+diff --git a/src/api/audio_codecs/audio_format.h b/src/api/audio_codecs/audio_format.h
+index edccc17..023ddb6 100644
+--- a/src/api/audio_codecs/audio_format.h
++++ b/src/api/audio_codecs/audio_format.h
+@@ -25,7 +25,7 @@ namespace webrtc {
+ 
+ // SDP specification for a single audio codec.
+ struct RTC_EXPORT SdpAudioFormat {
+-  using Parameters [[deprecated(("Use webrtc::CodecParameterMap"))]] =
++  using Parameters [[deprecated("Use webrtc::CodecParameterMap")]] =
+       std::map<std::string, std::string>;
+ 
+   SdpAudioFormat(const SdpAudioFormat&);
+diff --git a/src/api/video_codecs/sdp_video_format.h b/src/api/video_codecs/sdp_video_format.h
+index af9537b..9ee3ed1 100644
+--- a/src/api/video_codecs/sdp_video_format.h
++++ b/src/api/video_codecs/sdp_video_format.h
+@@ -26,7 +26,7 @@ namespace webrtc {
+ // SDP specification for a single video codec.
+ // NOTE: This class is still under development and may change without notice.
+ struct RTC_EXPORT SdpVideoFormat {
+-  using Parameters [[deprecated(("Use webrtc::CodecParameterMap"))]] =
++  using Parameters [[deprecated("Use webrtc::CodecParameterMap")]] =
+       std::map<std::string, std::string>;
+ 
+   explicit SdpVideoFormat(const std::string& name);


### PR DESCRIPTION
## Synopsis

`deprecated attribute` written with double bracket  that are ignored by the clang compiler but `msvc` getting error.


## Solution

Delete double bracket.


## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
    - [x] Has assignee
- Before [review][l:4]:
    - [x] Documentation is updated (if required)
    - [x] Tests are updated (if required)
    - [x] Changes conform [code style][l:2]
    - [x] [CHANGELOG entry][l:3] is added (if required)
    - [x] FCM (final commit message) is posted or updated
    - [x] [Draft mode][l:1] is removed
- [x] [Review][l:4] is completed and changes are approved
    - [x] FCM (final commit message) is approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: /CONTRIBUTING.md#code-style
[l:3]: /CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests