### PR TITLE
Add ARM iOS Simulator support

### DIFF
--- a/instrumentisto-libwebrtc-bin.podspec
+++ b/instrumentisto-libwebrtc-bin.podspec
@@ -12,9 +12,9 @@ Pod::Spec.new do |spec|
   spec.vendored_frameworks = "WebRTC.xcframework"
 
   spec.pod_target_xcconfig = {
-    'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64 i386',
+    'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'i386',
   }
   spec.user_target_xcconfig = {
-    'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64 i386',
+    'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'i386',
   }
 end


### PR DESCRIPTION
`libwebrtc-bin` is already supporting `arm64-simulator` arch, but we're excluding this architecture in the `instrumentisto-libwebrtc-bin.podspec`.

This PR removes `arm64` arch from list of `EXCLUDED_ARCHS` for iOS.

Proof that we're already support arm64 Simulator:

```sh
$ lipo -archs WebRTC.xcframework/ios-arm64_x86_64-simulator/WebRTC.framework/WebRTC
x86_64 arm64
```

Also arm64 Simulator support was tested locally on a Mac with Apple Silicon chip and everything works.