### PR TITLE
Upgrade MacOS CI runner version for iOS and MacOS builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
             arch: x64
           - os: windows
             arch: x64
-    runs-on: ${{ (contains('ios macos', matrix.os) && 'macos-11')
+    runs-on: ${{ (contains('ios macos', matrix.os) && 'macos-13')
               || (contains('windows', matrix.os)   && 'windows-2019')
               ||                                      'ubuntu-latest' }}
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
             arch: x64
           - os: windows
             arch: x64
-    runs-on: ${{ (contains('ios macos', matrix.os) && 'macos-13')
+    runs-on: ${{ (contains('ios macos', matrix.os) && 'macos-12')
               || (contains('windows', matrix.os)   && 'windows-2019')
               ||                                      'ubuntu-latest' }}
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,8 @@ jobs:
             arch: x64
           - os: windows
             arch: x64
-    # Opt for `macos-12` in iOS/MacOS builds to improve backward compatibility with older MacOS versions
+    # NOTE: Using `macos-12` instead of `macos-latest` is for improving backward
+    #       compatibility with older iOS/macOS versions.
     runs-on: ${{ (contains('ios macos', matrix.os) && 'macos-12')
               || (contains('windows', matrix.os)   && 'windows-2019')
               ||                                      'ubuntu-latest' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,7 @@ jobs:
             arch: x64
           - os: windows
             arch: x64
+    # Opt for `macos-12` in iOS/MacOS builds to improve backward compatibility with older MacOS versions
     runs-on: ${{ (contains('ios macos', matrix.os) && 'macos-12')
               || (contains('windows', matrix.os)   && 'windows-2019')
               ||                                      'ubuntu-latest' }}


### PR DESCRIPTION
## Summary

Build of `libwebrtc-bin` is broken at this moment, because of `macos-11` runner deprecation.

Failed job: https://github.com/instrumentisto/libwebrtc-bin/actions/runs/9547384899

Fail messages:

```
> build (ios)
> GitHub Actions has encountered an internal error when running your job.
> build (ios)
> This is a scheduled macOS-11 brownout. The macOS-11 environment is deprecated and will be removed on June 28th, 2024.
```

## Solution

Upgrade version of GitHub runners to `macos-13` (latest x86 runners).