### PR TITLE
Fix iOS video encoder patch

### DIFF
--- a/patch/enable_ios_scalability_mode.patch
+++ b/patch/enable_ios_scalability_mode.patch
@@ -1,5 +1,5 @@
 diff --git a/src/sdk/BUILD.gn b/src/sdk/BUILD.gn
-index d31673e..bb9b3cb 100644
+index 683d8e5829..5c22265dbf 100644
 --- a/src/sdk/BUILD.gn
 +++ b/src/sdk/BUILD.gn
 @@ -96,6 +96,8 @@ if (is_ios || is_mac) {
@@ -11,15 +11,15 @@ index d31673e..bb9b3cb 100644
        "objc/base/RTCI420Buffer.h",
        "objc/base/RTCLogging.h",
        "objc/base/RTCLogging.mm",
-@@ -729,6 +731,7 @@ if (is_ios || is_mac) {
+@@ -724,6 +726,7 @@ if (is_ios || is_mac) {
          ":vp8",
          ":vp9",
          ":vpx_codec_constants",
 +        ":wrapped_native_codec_objc",
        ]
- 
+
        defines = []
-@@ -769,6 +772,7 @@ if (is_ios || is_mac) {
+@@ -764,6 +767,7 @@ if (is_ios || is_mac) {
        deps = [
          ":base_objc",
          ":wrapped_native_codec_objc",
@@ -27,7 +27,7 @@ index d31673e..bb9b3cb 100644
          "../modules/video_coding:webrtc_vp8",
        ]
      }
-@@ -786,6 +790,7 @@ if (is_ios || is_mac) {
+@@ -781,6 +785,7 @@ if (is_ios || is_mac) {
        deps = [
          ":base_objc",
          ":wrapped_native_codec_objc",
@@ -35,7 +35,7 @@ index d31673e..bb9b3cb 100644
          "../modules/video_coding:webrtc_vp9",
        ]
      }
-@@ -817,6 +822,7 @@ if (is_ios || is_mac) {
+@@ -812,6 +817,7 @@ if (is_ios || is_mac) {
        deps = [
          ":base_objc",
          ":wrapped_native_codec_objc",
@@ -43,7 +43,7 @@ index d31673e..bb9b3cb 100644
          "../modules/video_coding/codecs/av1:libaom_av1_encoder",
        ]
      }
-@@ -1269,6 +1275,7 @@ if (is_ios || is_mac) {
+@@ -1273,6 +1279,7 @@ if (is_ios || is_mac) {
            "objc/base/RTCVideoDecoder.h",
            "objc/base/RTCVideoDecoderFactory.h",
            "objc/base/RTCVideoEncoder.h",
@@ -51,16 +51,15 @@ index d31673e..bb9b3cb 100644
            "objc/base/RTCVideoEncoderFactory.h",
            "objc/base/RTCVideoEncoderQpThresholds.h",
            "objc/base/RTCVideoEncoderSettings.h",
-@@ -1345,6 +1352,8 @@ if (is_ios || is_mac) {
+@@ -1350,6 +1357,7 @@ if (is_ios || is_mac) {
            "objc/api/video_codec/RTCVideoEncoderAV1.h",
            "objc/api/video_frame_buffer/RTCNativeI420Buffer.h",
            "objc/api/video_frame_buffer/RTCNativeMutableI420Buffer.h",
-+          "objc/api/video_codec/RTCWrappedNativeVideoDecoderFactory.h",
 +          "objc/api/video_codec/RTCWrappedNativeVideoEncoderFactory.h",
          ]
- 
+
          if (!build_with_chromium) {
-@@ -1371,6 +1380,7 @@ if (is_ios || is_mac) {
+@@ -1376,6 +1384,7 @@ if (is_ios || is_mac) {
            ":native_api",
            ":native_video",
            ":peerconnectionfactory_base_objc",
@@ -68,7 +67,7 @@ index d31673e..bb9b3cb 100644
            ":videocapture_objc",
            ":videocodec_objc",
            ":videotoolbox_objc",
-@@ -1471,6 +1481,7 @@ if (is_ios || is_mac) {
+@@ -1477,6 +1486,7 @@ if (is_ios || is_mac) {
            "objc/base/RTCVideoDecoder.h",
            "objc/base/RTCVideoDecoderFactory.h",
            "objc/base/RTCVideoEncoder.h",
@@ -76,7 +75,7 @@ index d31673e..bb9b3cb 100644
            "objc/base/RTCVideoEncoderFactory.h",
            "objc/base/RTCVideoEncoderQpThresholds.h",
            "objc/base/RTCVideoEncoderSettings.h",
-@@ -1506,6 +1517,7 @@ if (is_ios || is_mac) {
+@@ -1513,6 +1523,7 @@ if (is_ios || is_mac) {
            ":native_api",
            ":native_video",
            ":peerconnectionfactory_base_objc",
@@ -84,22 +83,18 @@ index d31673e..bb9b3cb 100644
            ":videocapture_objc",
            ":videocodec_objc",
            ":videotoolbox_objc",
-@@ -1544,6 +1556,14 @@ if (is_ios || is_mac) {
+@@ -1551,6 +1562,10 @@ if (is_ios || is_mac) {
          "objc/api/video_codec/RTCNativeVideoEncoder.h",
          "objc/api/video_codec/RTCNativeVideoEncoder.mm",
          "objc/api/video_codec/RTCNativeVideoEncoderBuilder+Native.h",
-+        "objc/api/video_codec/RTCWrappedNativeVideoDecoder.h",
-+        "objc/api/video_codec/RTCWrappedNativeVideoDecoder.mm",
 +        "objc/api/video_codec/RTCWrappedNativeVideoEncoder.h",
 +        "objc/api/video_codec/RTCWrappedNativeVideoEncoder.mm",
-+        "objc/api/video_codec/RTCWrappedNativeVideoDecoderFactory.h",
-+        "objc/api/video_codec/RTCWrappedNativeVideoDecoderFactory.mm",
 +        "objc/api/video_codec/RTCWrappedNativeVideoEncoderFactory.h",
 +        "objc/api/video_codec/RTCWrappedNativeVideoEncoderFactory.mm",
        ]
- 
+
        configs += [ "..:common_objc" ]
-@@ -1554,8 +1574,12 @@ if (is_ios || is_mac) {
+@@ -1561,8 +1576,12 @@ if (is_ios || is_mac) {
          ":helpers_objc",
          "../api/environment",
          "../api/video_codecs:video_codecs_api",
@@ -111,15 +106,15 @@ index d31673e..bb9b3cb 100644
 +        ":base_native_additions_objc",
        ]
      }
- 
+
 diff --git a/src/sdk/objc/api/peerconnection/RTCRtpEncodingParameters.h b/src/sdk/objc/api/peerconnection/RTCRtpEncodingParameters.h
-index 07f6b7a..d055115 100644
+index 07f6b7a39c..d055115ae2 100644
 --- a/src/sdk/objc/api/peerconnection/RTCRtpEncodingParameters.h
 +++ b/src/sdk/objc/api/peerconnection/RTCRtpEncodingParameters.h
 @@ -51,6 +51,10 @@ RTC_OBJC_EXPORT
   */
  @property(nonatomic, copy, nullable) NSNumber *numTemporalLayers;
- 
+
 +/** A case-sensitive identifier of the scalability mode to be used for this stream.
 +  https://w3c.github.io/webrtc-svc/#rtcrtpencodingparameters */
 +@property(nonatomic, copy, nullable) NSString *scalabilityMode;
@@ -128,10 +123,10 @@ index 07f6b7a..d055115 100644
   * implementation default scaling factor will be used.
   */
 diff --git a/src/sdk/objc/api/peerconnection/RTCRtpEncodingParameters.mm b/src/sdk/objc/api/peerconnection/RTCRtpEncodingParameters.mm
-index d6087da..5fc7670 100644
+index d6087dafb0..5fc7670857 100644
 --- a/src/sdk/objc/api/peerconnection/RTCRtpEncodingParameters.mm
 +++ b/src/sdk/objc/api/peerconnection/RTCRtpEncodingParameters.mm
-@@ -20,6 +20,7 @@ @implementation RTC_OBJC_TYPE (RTCRtpEncodingParameters)
+@@ -20,6 +20,7 @@
  @synthesize minBitrateBps = _minBitrateBps;
  @synthesize maxFramerate = _maxFramerate;
  @synthesize numTemporalLayers = _numTemporalLayers;
@@ -139,7 +134,7 @@ index d6087da..5fc7670 100644
  @synthesize scaleResolutionDownBy = _scaleResolutionDownBy;
  @synthesize ssrc = _ssrc;
  @synthesize bitratePriority = _bitratePriority;
-@@ -52,6 +53,10 @@ - (instancetype)initWithNativeParameters:
+@@ -52,6 +53,10 @@
      if (nativeParameters.num_temporal_layers) {
        _numTemporalLayers = [NSNumber numberWithInt:*nativeParameters.num_temporal_layers];
      }
@@ -150,7 +145,7 @@ index d6087da..5fc7670 100644
      if (nativeParameters.scale_resolution_down_by) {
        _scaleResolutionDownBy =
            [NSNumber numberWithDouble:*nativeParameters.scale_resolution_down_by];
-@@ -85,6 +90,10 @@ - (instancetype)initWithNativeParameters:
+@@ -85,6 +90,10 @@
    if (_numTemporalLayers != nil) {
      parameters.num_temporal_layers = absl::optional<int>(_numTemporalLayers.intValue);
    }
@@ -162,20 +157,20 @@ index d6087da..5fc7670 100644
      parameters.scale_resolution_down_by =
          absl::optional<double>(_scaleResolutionDownBy.doubleValue);
 diff --git a/src/sdk/objc/api/peerconnection/RTCVideoCodecInfo+Private.mm b/src/sdk/objc/api/peerconnection/RTCVideoCodecInfo+Private.mm
-index 2eb8d36..5cc28aa 100644
+index 2eb8d366d2..5cc28aafa7 100644
 --- a/src/sdk/objc/api/peerconnection/RTCVideoCodecInfo+Private.mm
 +++ b/src/sdk/objc/api/peerconnection/RTCVideoCodecInfo+Private.mm
 @@ -12,6 +12,9 @@
- 
+
  #import "helpers/NSString+StdString.h"
- 
+
 +#include "api/video_codecs/scalability_mode.h"
 +#include "absl/container/inlined_vector.h"
 +
  @implementation RTC_OBJC_TYPE (RTCVideoCodecInfo)
  (Private)
- 
-@@ -21,10 +24,36 @@ - (instancetype)initWithNativeSdpVideoFormat : (webrtc::SdpVideoFormat)format {
+
+@@ -21,10 +24,36 @@
      [params setObject:[NSString stringForStdString:it->second]
                 forKey:[NSString stringForStdString:it->first]];
    }
@@ -193,7 +188,7 @@ index 2eb8d36..5cc28aa 100644
 +
 +  return [self initWithName:[NSString stringForStdString:format.name] parameters:params scalabiltyModes: scalability_modes];
  }
- 
+
  - (webrtc::SdpVideoFormat)nativeSdpVideoFormat {
 +  absl::InlinedVector<webrtc::ScalabilityMode, webrtc::kScalabilityModeCount>
 +      scalability_modes;
@@ -213,257 +208,22 @@ index 2eb8d36..5cc28aa 100644
    std::map<std::string, std::string> parameters;
    for (NSString *paramKey in self.parameters.allKeys) {
      std::string key = [NSString stdStringForString:paramKey];
-@@ -32,7 +61,8 @@ - (instancetype)initWithNativeSdpVideoFormat : (webrtc::SdpVideoFormat)format {
+@@ -32,7 +61,8 @@
      parameters[key] = value;
    }
- 
+
 -  return webrtc::SdpVideoFormat([NSString stdStringForString:self.name], parameters);
 +  return webrtc::SdpVideoFormat([NSString stdStringForString:self.name],
 +                                parameters, scalability_modes);
  }
- 
+
  @end
-diff --git a/src/sdk/objc/api/video_codec/RTCWrappedNativeVideoDecoder.h b/src/sdk/objc/api/video_codec/RTCWrappedNativeVideoDecoder.h
-new file mode 100644
-index 0000000..3a9b39e
---- /dev/null
-+++ b/src/sdk/objc/api/video_codec/RTCWrappedNativeVideoDecoder.h
-@@ -0,0 +1,26 @@
-+/*
-+ *  Copyright (c) 2017 The WebRTC project authors. All Rights Reserved.
-+ *
-+ *  Use of this source code is governed by a BSD-style license
-+ *  that can be found in the LICENSE file in the root of the source
-+ *  tree. An additional intellectual property rights grant can be found
-+ *  in the file PATENTS.  All contributing project authors may
-+ *  be found in the AUTHORS file in the root of the source tree.
-+ */
-+
-+#import <Foundation/Foundation.h>
-+
-+#import "base/RTCMacros.h"
-+#import "base/RTCVideoDecoder.h"
-+
-+#include "api/video_codecs/video_decoder.h"
-+#include "media/base/codec.h"
-+
-+@interface RTC_OBJC_TYPE (RTCWrappedNativeVideoDecoder) : NSObject <RTC_OBJC_TYPE (RTCVideoDecoder)>
-+
-+- (instancetype)initWithNativeDecoder:(std::unique_ptr<webrtc::VideoDecoder>)decoder;
-+
-+/* This moves the ownership of the wrapped decoder to the caller. */
-+- (std::unique_ptr<webrtc::VideoDecoder>)releaseWrappedDecoder;
-+
-+@end
-diff --git a/src/sdk/objc/api/video_codec/RTCWrappedNativeVideoDecoder.mm b/src/sdk/objc/api/video_codec/RTCWrappedNativeVideoDecoder.mm
-new file mode 100644
-index 0000000..29d2265
---- /dev/null
-+++ b/src/sdk/objc/api/video_codec/RTCWrappedNativeVideoDecoder.mm
-@@ -0,0 +1,63 @@
-+/*
-+ *  Copyright (c) 2017 The WebRTC project authors. All Rights Reserved.
-+ *
-+ *  Use of this source code is governed by a BSD-style license
-+ *  that can be found in the LICENSE file in the root of the source
-+ *  tree. An additional intellectual property rights grant can be found
-+ *  in the file PATENTS.  All contributing project authors may
-+ *  be found in the AUTHORS file in the root of the source tree.
-+ */
-+
-+#import <Foundation/Foundation.h>
-+
-+#import "RTCWrappedNativeVideoDecoder.h"
-+#import "base/RTCMacros.h"
-+#import "helpers/NSString+StdString.h"
-+
-+@implementation RTC_OBJC_TYPE (RTCWrappedNativeVideoDecoder) {
-+  std::unique_ptr<webrtc::VideoDecoder> _wrappedDecoder;
-+}
-+
-+- (instancetype)initWithNativeDecoder:(std::unique_ptr<webrtc::VideoDecoder>)decoder {
-+  if (self = [super init]) {
-+    _wrappedDecoder = std::move(decoder);
-+  }
-+
-+  return self;
-+}
-+
-+- (std::unique_ptr<webrtc::VideoDecoder>)releaseWrappedDecoder {
-+  return std::move(_wrappedDecoder);
-+}
-+
-+#pragma mark - RTC_OBJC_TYPE(RTCVideoDecoder)
-+
-+- (void)setCallback:(RTCVideoDecoderCallback)callback {
-+  RTC_DCHECK_NOTREACHED();
-+}
-+
-+- (NSInteger)startDecodeWithNumberOfCores:(int)numberOfCores {
-+  RTC_DCHECK_NOTREACHED();
-+  return 0;
-+}
-+
-+- (NSInteger)releaseDecoder {
-+  RTC_DCHECK_NOTREACHED();
-+  return 0;
-+}
-+
-+// TODO(bugs.webrtc.org/15444): Remove obsolete missingFrames param.
-+- (NSInteger)decode:(RTC_OBJC_TYPE(RTCEncodedImage) *)encodedImage
-+        missingFrames:(BOOL)missingFrames
-+    codecSpecificInfo:(nullable id<RTC_OBJC_TYPE(RTCCodecSpecificInfo)>)info
-+         renderTimeMs:(int64_t)renderTimeMs {
-+  RTC_DCHECK_NOTREACHED();
-+  return 0;
-+}
-+
-+- (NSString *)implementationName {
-+  RTC_DCHECK_NOTREACHED();
-+  return nil;
-+}
-+
-+@end
-diff --git a/src/sdk/objc/api/video_codec/RTCWrappedNativeVideoDecoderFactory.h b/src/sdk/objc/api/video_codec/RTCWrappedNativeVideoDecoderFactory.h
-new file mode 100644
-index 0000000..ed4745a
---- /dev/null
-+++ b/src/sdk/objc/api/video_codec/RTCWrappedNativeVideoDecoderFactory.h
-@@ -0,0 +1,30 @@
-+/*
-+ *  Copyright 2023 The WebRTC project authors. All Rights Reserved.
-+ *
-+ *  Use of this source code is governed by a BSD-style license
-+ *  that can be found in the LICENSE file in the root of the source
-+ *  tree. An additional intellectual property rights grant can be found
-+ *  in the file PATENTS.  All contributing project authors may
-+ *  be found in the AUTHORS file in the root of the source tree.
-+ */
-+
-+#import <Foundation/Foundation.h>
-+
-+#import "RTCMacros.h"
-+#import "RTCVideoDecoderFactory.h"
-+#import "components/video_codec/RTCVideoDecoderFactoryH264.h"
-+
-+NS_ASSUME_NONNULL_BEGIN
-+
-+/** This decoder factory include support for all codecs bundled with WebRTC. If
-+ * using custom codecs, create custom implementations of RTCVideoDecoderFactory.
-+ */
-+RTC_OBJC_EXPORT
-+@interface RTC_OBJC_TYPE (RTCWrapperNativeVideoDecoderFactory) : NSObject <RTC_OBJC_TYPE(RTCVideoDecoderFactory)>
-+@property(nonatomic, strong) RTC_OBJC_TYPE(RTCVideoDecoderFactoryH264) *HWVideoDecoderFactory;
-+
-+- (instancetype)initWithTemplateFactory;
-+
-+@end
-+
-+NS_ASSUME_NONNULL_END
-diff --git a/src/sdk/objc/api/video_codec/RTCWrappedNativeVideoDecoderFactory.mm b/src/sdk/objc/api/video_codec/RTCWrappedNativeVideoDecoderFactory.mm
-new file mode 100644
-index 0000000..591ef4d
---- /dev/null
-+++ b/src/sdk/objc/api/video_codec/RTCWrappedNativeVideoDecoderFactory.mm
-@@ -0,0 +1,92 @@
-+/*
-+ *  Copyright (c) 2013 The WebRTC project authors. All Rights Reserved.
-+ *
-+ *  Use of this source code is governed by a BSD-style license
-+ *  that can be found in the LICENSE file in the root of the source
-+ *  tree. An additional intellectual property rights grant can be found
-+ *  in the file PATENTS.  All contributing project authors may
-+ *  be found in the AUTHORS file in the root of the source tree.
-+ */
-+
-+#import "RTCWrappedNativeVideoDecoderFactory.h"
-+
-+#import <Foundation/Foundation.h>
-+
-+#import "RTCWrappedNativeVideoDecoder.h"
-+#import "api/peerconnection/RTCVideoCodecInfo+Private.h"
-+#include "api/video_codecs/video_decoder_factory.h"
-+#include "api/video_codecs/video_decoder_factory_template.h"
-+#include "api/video_codecs/video_decoder_factory_template_dav1d_adapter.h"
-+#include "api/video_codecs/video_decoder_factory_template_libvpx_vp8_adapter.h"
-+#include "api/video_codecs/video_decoder_factory_template_libvpx_vp9_adapter.h"
-+#include "api/video_codecs/video_decoder_factory_template_open_h264_adapter.h"
-+#include "api/environment/environment_factory.h"
-+#import "base/RTCMacros.h"
-+#import "base/RTCVideoCodecInfo.h"
-+#import "components/video_codec/RTCVideoDecoderFactoryH264.h"
-+#import "helpers/NSString+StdString.h"
-+#import "components/video_codec/RTCH264ProfileLevelId.h"
-+
-+@implementation RTC_OBJC_TYPE (RTCWrapperNativeVideoDecoderFactory) {
-+  std::unique_ptr<webrtc::VideoDecoderFactory> _wrappedFactory;
-+  std::unique_ptr<webrtc::Environment> _env;
-+}
-+
-+@synthesize HWVideoDecoderFactory = _HWVideoDecoderFactory;
-+
-+- (instancetype)initWithTemplateFactory {
-+  if (self = [super init]) {
-+    _wrappedFactory = std::make_unique<webrtc::VideoDecoderFactoryTemplate<
-+        webrtc::LibvpxVp8DecoderTemplateAdapter,
-+        webrtc::LibvpxVp9DecoderTemplateAdapter,
-+        webrtc::OpenH264DecoderTemplateAdapter,
-+        webrtc::Dav1dDecoderTemplateAdapter>>();
-+    _env = std::make_unique<webrtc::Environment>(webrtc::CreateEnvironment());
-+  }
-+  _HWVideoDecoderFactory = [[RTC_OBJC_TYPE(RTCVideoDecoderFactoryH264) alloc] init];
-+  return self;
-+}
-+
-+#pragma mark - RTC_OBJC_TYPE(RTCVideoDecoderFactory)
-+
-+- (nullable id<RTC_OBJC_TYPE(RTCVideoDecoder)>)createDecoder:
-+    (RTC_OBJC_TYPE(RTCVideoCodecInfo) *)info {
-+  if ([info.name isEqualToString:kRTCVideoCodecH264Name]) {
-+    return [_HWVideoDecoderFactory createDecoder:info];
-+  }
-+
-+  std::map<std::string, std::string> parameters;
-+  for (NSString* paramKey in info.parameters.allKeys) {
-+    std::string key = [NSString stdStringForString:paramKey];
-+    std::string value = [NSString stdStringForString:info.parameters[paramKey]];
-+    parameters[key] = value;
-+  }
-+
-+  auto format = webrtc::SdpVideoFormat([NSString stdStringForString:info.name],
-+                                       parameters);
-+
-+  return [[RTC_OBJC_TYPE(RTCWrappedNativeVideoDecoder) alloc]
-+      initWithNativeDecoder:_wrappedFactory->Create(*_env, format)];
-+}
-+
-+- (NSArray<RTC_OBJC_TYPE(RTCVideoCodecInfo) *>*)supportedCodecs {
-+  auto formats = _wrappedFactory->GetSupportedFormats();
-+  auto HWSupportedCodecs = [_HWVideoDecoderFactory supportedCodecs];
-+
-+  NSMutableArray<RTC_OBJC_TYPE(RTCVideoCodecInfo)*>* result = [@[] mutableCopy];
-+
-+  NSUInteger i;
-+  for (i = 0; i < [HWSupportedCodecs count]; i++) {
-+    [result addObject:[HWSupportedCodecs objectAtIndex:i]];
-+  }
-+
-+  for (size_t i = 0; i < formats.size(); ++i) {
-+    RTC_OBJC_TYPE(RTCVideoCodecInfo)* info = [[RTC_OBJC_TYPE(RTCVideoCodecInfo)
-+        alloc] initWithNativeSdpVideoFormat:formats[i]];
-+
-+    [result addObject:info];
-+  }
-+  return result;
-+}
-+
-+@end
 diff --git a/src/sdk/objc/api/video_codec/RTCWrappedNativeVideoEncoder.h b/src/sdk/objc/api/video_codec/RTCWrappedNativeVideoEncoder.h
 new file mode 100644
-index 0000000..72b473c
+index 0000000000..d639eaee31
 --- /dev/null
 +++ b/src/sdk/objc/api/video_codec/RTCWrappedNativeVideoEncoder.h
-@@ -0,0 +1,22 @@
+@@ -0,0 +1,21 @@
 +/*
 + *  Copyright (c) 2017 The WebRTC project authors. All Rights Reserved.
 + *
@@ -477,22 +237,20 @@ index 0000000..72b473c
 +#import "RTCNativeVideoEncoder.h"
 +#import "base/RTCMacros.h"
 +#import "base/RTCVideoEncoder.h"
++#include "api/video_codecs/video_encoder_factory.h"
 +#include "api/video_codecs/sdp_video_format.h"
 +#include "api/video_codecs/video_encoder.h"
 +#include "media/base/codec.h"
-+// TODO: bugs.webrtc.org/15860 - Remove in favor of the RTCNativeVideoEncoderBuilder
-+@interface RTC_OBJC_TYPE (RTCWrappedNativeVideoEncoder) : RTC_OBJC_TYPE (RTCNativeVideoEncoder)
-+- (instancetype)initWithNativeEncoder:(std::unique_ptr<webrtc::VideoEncoder>)encoder;
-+/* This moves the ownership of the wrapped encoder to the caller. */
-+- (std::unique_ptr<webrtc::VideoEncoder>)releaseWrappedEncoder;
++
++@interface RTC_OBJC_TYPE (RTCWrappedNativeVideoEncoder) : NSObject
+++ (id<RTC_OBJC_TYPE(RTCVideoEncoder)>)wrap:(std::shared_ptr<webrtc::VideoEncoderFactory>)factory :(webrtc::SdpVideoFormat)format;
 +@end
-\ No newline at end of file
 diff --git a/src/sdk/objc/api/video_codec/RTCWrappedNativeVideoEncoder.mm b/src/sdk/objc/api/video_codec/RTCWrappedNativeVideoEncoder.mm
 new file mode 100644
-index 0000000..69b0961
+index 0000000000..4b9ef7cc67
 --- /dev/null
 +++ b/src/sdk/objc/api/video_codec/RTCWrappedNativeVideoEncoder.mm
-@@ -0,0 +1,25 @@
+@@ -0,0 +1,45 @@
 +/*
 + *  Copyright (c) 2017 The WebRTC project authors. All Rights Reserved.
 + *
@@ -502,26 +260,45 @@ index 0000000..69b0961
 + *  in the file PATENTS.  All contributing project authors may
 + *  be found in the AUTHORS file in the root of the source tree.
 + */
++#import "base/RTCLogging.h"
 +#import <Foundation/Foundation.h>
 +#import "RTCWrappedNativeVideoEncoder.h"
-+#import "base/RTCMacros.h"
-+@implementation RTC_OBJC_TYPE (RTCWrappedNativeVideoEncoder) {
-+  std::unique_ptr<webrtc::VideoEncoder> _wrappedEncoder;
-+}
-+- (instancetype)initWithNativeEncoder:(std::unique_ptr<webrtc::VideoEncoder>)encoder {
-+  if (self = [super init]) {
-+    _wrappedEncoder = std::move(encoder);
-+  }
-+  return self;
-+}
-+- (std::unique_ptr<webrtc::VideoEncoder>)releaseWrappedEncoder {
-+  return std::move(_wrappedEncoder);
-+}
++#import "RTCMacros.h"
++#import "RTCNativeVideoEncoder.h"
++#import "RTCNativeVideoEncoderBuilder+Native.h"
++
++@interface RTC_OBJC_TYPE (RTCWrappedNativeVideoEncoderBuilder)
++        : RTC_OBJC_TYPE(RTCNativeVideoEncoder) <RTC_OBJC_TYPE (RTCNativeVideoEncoderBuilder)>
 +@end
-\ No newline at end of file
++
++    @implementation RTC_OBJC_TYPE (RTCWrappedNativeVideoEncoderBuilder){
++        std::shared_ptr<webrtc::VideoEncoderFactory> _factory;
++        std::optional<webrtc::SdpVideoFormat> _format;
++    }
++
++    -(id)initWithParams:(std::shared_ptr<webrtc::VideoEncoderFactory>)factory :(webrtc::SdpVideoFormat)format
++    {
++        if(self = [super init]) {
++            _factory = factory;
++            _format = format;
++        }
++
++        return self;
++    }
++
++    - (std::unique_ptr<webrtc::VideoEncoder>)build:(const webrtc::Environment&)env {
++        return _factory->Create(env, _format.value());
++    }
++    @end
++
++    @implementation RTC_OBJC_TYPE (RTCWrappedNativeVideoEncoder)
++    + (id<RTC_OBJC_TYPE(RTCVideoEncoder)>)wrap:(std::shared_ptr<webrtc::VideoEncoderFactory>)factory :(webrtc::SdpVideoFormat)format {
++        return [[RTC_OBJC_TYPE(RTCWrappedNativeVideoEncoderBuilder) alloc] initWithParams:factory:format];
++    }
++    @end
 diff --git a/src/sdk/objc/api/video_codec/RTCWrappedNativeVideoEncoderFactory.h b/src/sdk/objc/api/video_codec/RTCWrappedNativeVideoEncoderFactory.h
 new file mode 100644
-index 0000000..ae4b2f5
+index 0000000000..ae4b2f5a16
 --- /dev/null
 +++ b/src/sdk/objc/api/video_codec/RTCWrappedNativeVideoEncoderFactory.h
 @@ -0,0 +1,30 @@
@@ -557,10 +334,10 @@ index 0000000..ae4b2f5
 +NS_ASSUME_NONNULL_END
 diff --git a/src/sdk/objc/api/video_codec/RTCWrappedNativeVideoEncoderFactory.mm b/src/sdk/objc/api/video_codec/RTCWrappedNativeVideoEncoderFactory.mm
 new file mode 100644
-index 0000000..773b7a1
+index 0000000000..be788495fd
 --- /dev/null
 +++ b/src/sdk/objc/api/video_codec/RTCWrappedNativeVideoEncoderFactory.mm
-@@ -0,0 +1,156 @@
+@@ -0,0 +1,158 @@
 +/*
 + *  Copyright (c) 2017 The WebRTC project authors. All Rights Reserved.
 + *
@@ -575,6 +352,7 @@ index 0000000..773b7a1
 +
 +#import <Foundation/Foundation.h>
 +
++#import "base/RTCLogging.h"
 +#import "RTCWrappedNativeVideoEncoder.h"
 +#include "absl/container/inlined_vector.h"
 +#import "api/peerconnection/RTCVideoCodecInfo+Private.h"
@@ -593,14 +371,14 @@ index 0000000..773b7a1
 +#import "components/video_codec/RTCH264ProfileLevelId.h"
 +
 +@implementation RTC_OBJC_TYPE (RTCWrapperNativeVideoEncoderFactory) {
-+  std::unique_ptr<webrtc::VideoEncoderFactory> _wrappedFactory;
++  std::shared_ptr<webrtc::VideoEncoderFactory> _wrappedFactory;
 +  std::unique_ptr<webrtc::Environment> _env;
 +}
 +@synthesize HWVideoEncoderFactory = _HWVideoEncoderFactory;
 +
 +- (instancetype)initWithTemplateFactory {
 +  if (self = [super init]) {
-+    _wrappedFactory = std::make_unique<webrtc::VideoEncoderFactoryTemplate<
++    _wrappedFactory = std::make_shared<webrtc::VideoEncoderFactoryTemplate<
 +        webrtc::LibvpxVp8EncoderTemplateAdapter,
 +        webrtc::LibvpxVp9EncoderTemplateAdapter,
 +        webrtc::OpenH264EncoderTemplateAdapter,
@@ -615,6 +393,8 @@ index 0000000..773b7a1
 +
 +- (nullable id<RTC_OBJC_TYPE(RTCVideoEncoder)>)createEncoder:
 +    (RTC_OBJC_TYPE(RTCVideoCodecInfo) *)info {
++  RTCLogError("RTCWrapperNativeVideoEncoderFactory::createEncoder call");
++
 +  if ([info.name isEqualToString:kRTCVideoCodecH264Name]) {
 +    return [_HWVideoEncoderFactory createEncoder:info];
 +  }
@@ -644,8 +424,7 @@ index 0000000..773b7a1
 +  auto format = webrtc::SdpVideoFormat([NSString stdStringForString:info.name],
 +                                       parameters, scalability_modes);
 +
-+  return [[RTC_OBJC_TYPE(RTCWrappedNativeVideoEncoder) alloc]
-+      initWithNativeEncoder:_wrappedFactory->Create(*_env, format)];
++  return [RTC_OBJC_TYPE(RTCWrappedNativeVideoEncoder) wrap:_wrappedFactory:format];
 +}
 +
 +- (NSArray<RTC_OBJC_TYPE(RTCVideoCodecInfo) *>*)supportedCodecs {
@@ -719,7 +498,7 @@ index 0000000..773b7a1
 +@end
 diff --git a/src/sdk/objc/base/RTCCodecSupport.h b/src/sdk/objc/base/RTCCodecSupport.h
 new file mode 100644
-index 0000000..e20bf4e
+index 0000000000..e20bf4e4d3
 --- /dev/null
 +++ b/src/sdk/objc/base/RTCCodecSupport.h
 @@ -0,0 +1,24 @@
@@ -749,7 +528,7 @@ index 0000000..e20bf4e
 +NS_ASSUME_NONNULL_END
 diff --git a/src/sdk/objc/base/RTCCodecSupport.m b/src/sdk/objc/base/RTCCodecSupport.m
 new file mode 100644
-index 0000000..2d98044
+index 0000000000..2d98044449
 --- /dev/null
 +++ b/src/sdk/objc/base/RTCCodecSupport.m
 @@ -0,0 +1,18 @@
@@ -772,39 +551,39 @@ index 0000000..2d98044
 +
 +@end
 diff --git a/src/sdk/objc/base/RTCVideoCodecInfo.h b/src/sdk/objc/base/RTCVideoCodecInfo.h
-index fa28958..18b6d61 100644
+index fa28958f25..18b6d613e6 100644
 --- a/src/sdk/objc/base/RTCVideoCodecInfo.h
 +++ b/src/sdk/objc/base/RTCVideoCodecInfo.h
 @@ -24,12 +24,14 @@ RTC_OBJC_EXPORT
- 
+
  - (instancetype)initWithName:(NSString *)name
                    parameters:(nullable NSDictionary<NSString *, NSString *> *)parameters
 +                  scalabiltyModes:(nullable NSArray<NSString *> *)scalabiltyModes
      NS_DESIGNATED_INITIALIZER;
- 
+
  - (BOOL)isEqualToCodecInfo:(RTC_OBJC_TYPE(RTCVideoCodecInfo) *)info;
- 
+
  @property(nonatomic, readonly) NSString *name;
  @property(nonatomic, readonly) NSDictionary<NSString *, NSString *> *parameters;
 +@property(nonatomic, readonly) NSArray<NSString *> *scalabiltyModes;
- 
+
  @end
- 
+
 diff --git a/src/sdk/objc/base/RTCVideoCodecInfo.m b/src/sdk/objc/base/RTCVideoCodecInfo.m
-index ce26ae1..27a2b35 100644
+index ce26ae1de3..27a2b3594d 100644
 --- a/src/sdk/objc/base/RTCVideoCodecInfo.m
 +++ b/src/sdk/objc/base/RTCVideoCodecInfo.m
-@@ -14,16 +14,21 @@ @implementation RTC_OBJC_TYPE (RTCVideoCodecInfo)
- 
+@@ -14,16 +14,21 @@
+
  @synthesize name = _name;
  @synthesize parameters = _parameters;
 +@synthesize scalabiltyModes = _scalabiltyModes;
- 
+
  - (instancetype)initWithName:(NSString *)name {
 -  return [self initWithName:name parameters:nil];
 +  return [self initWithName:name parameters:nil scalabiltyModes:nil];
  }
- 
+
 -- (instancetype)initWithName:(NSString *)name
 -                  parameters:(nullable NSDictionary<NSString *, NSString *> *)parameters {
 +- (instancetype)initWithName:(NSString*)name
@@ -817,26 +596,26 @@ index ce26ae1..27a2b35 100644
 +    _scalabiltyModes =
 +        (scalabiltyModes ? scalabiltyModes : (NSArray<NSString*>*)(@{}));
    }
- 
+
    return self;
-@@ -54,12 +59,14 @@ - (NSUInteger)hash {
- 
+@@ -54,12 +59,14 @@
+
  - (instancetype)initWithCoder:(NSCoder *)decoder {
    return [self initWithName:[decoder decodeObjectForKey:@"name"]
 -                 parameters:[decoder decodeObjectForKey:@"parameters"]];
 +                 parameters:[decoder decodeObjectForKey:@"parameters"]
 +                 scalabiltyModes:[decoder decodeObjectForKey:@"scalabiltyModes"]];
  }
- 
+
  - (void)encodeWithCoder:(NSCoder *)encoder {
    [encoder encodeObject:_name forKey:@"name"];
    [encoder encodeObject:_parameters forKey:@"parameters"];
 +  [encoder encodeObject:_scalabiltyModes forKey:@"scalabiltyModes"];
  }
- 
+
  @end
 diff --git a/src/sdk/objc/base/RTCVideoEncoderFactory.h b/src/sdk/objc/base/RTCVideoEncoderFactory.h
-index a73cd77..39c09f1 100644
+index a73cd77990..39c09f1072 100644
 --- a/src/sdk/objc/base/RTCVideoEncoderFactory.h
 +++ b/src/sdk/objc/base/RTCVideoEncoderFactory.h
 @@ -13,6 +13,7 @@
@@ -844,13 +623,13 @@ index a73cd77..39c09f1 100644
  #import "RTCVideoCodecInfo.h"
  #import "RTCVideoEncoder.h"
 +#import "RTCCodecSupport.h"
- 
+
  NS_ASSUME_NONNULL_BEGIN
- 
+
 @@ -43,6 +44,10 @@ RTC_OBJC_EXPORT
  - (NSArray<RTC_OBJC_TYPE(RTCVideoCodecInfo) *> *)
      supportedCodecs;  // TODO(andersc): "supportedFormats" instead?
- 
+
 +- (RTC_OBJC_TYPE(RTCCodecSupport*))queryCodecSupport
 +: (RTC_OBJC_TYPE(RTCVideoCodecInfo) *)info
 +: (NSString *)scalabilityMode;
@@ -860,7 +639,7 @@ index a73cd77..39c09f1 100644
  - (nullable id<RTC_OBJC_TYPE(RTCVideoEncoderSelector)>)encoderSelector;
 diff --git a/src/sdk/objc/components/video_codec/MediaCodecUtils.h b/src/sdk/objc/components/video_codec/MediaCodecUtils.h
 new file mode 100644
-index 0000000..76aee1a
+index 0000000000..76aee1ad8b
 --- /dev/null
 +++ b/src/sdk/objc/components/video_codec/MediaCodecUtils.h
 @@ -0,0 +1,59 @@
@@ -923,148 +702,69 @@ index 0000000..76aee1a
 +    @"L1T2", \
 +    @"L1T3", \
 +    nil]
-diff --git a/src/sdk/objc/components/video_codec/RTCDefaultVideoDecoderFactory.h b/src/sdk/objc/components/video_codec/RTCDefaultVideoDecoderFactory.h
-index de5a9c4..54d1f69 100644
---- a/src/sdk/objc/components/video_codec/RTCDefaultVideoDecoderFactory.h
-+++ b/src/sdk/objc/components/video_codec/RTCDefaultVideoDecoderFactory.h
-@@ -12,6 +12,7 @@
- 
- #import "RTCMacros.h"
- #import "RTCVideoDecoderFactory.h"
-+#import "api/video_codec/RTCWrappedNativeVideoDecoderFactory.h"
- 
- NS_ASSUME_NONNULL_BEGIN
- 
-@@ -21,6 +22,7 @@ NS_ASSUME_NONNULL_BEGIN
-  */
- RTC_OBJC_EXPORT
- @interface RTC_OBJC_TYPE (RTCDefaultVideoDecoderFactory) : NSObject <RTC_OBJC_TYPE(RTCVideoDecoderFactory)>
-+@property(nonatomic, strong) RTC_OBJC_TYPE(RTCWrapperNativeVideoDecoderFactory) *factory;
- @end
- 
- NS_ASSUME_NONNULL_END
 diff --git a/src/sdk/objc/components/video_codec/RTCDefaultVideoDecoderFactory.m b/src/sdk/objc/components/video_codec/RTCDefaultVideoDecoderFactory.m
-index 6e3baa8..5f30842 100644
+index 6e3baa8750..34f41df595 100644
 --- a/src/sdk/objc/components/video_codec/RTCDefaultVideoDecoderFactory.m
 +++ b/src/sdk/objc/components/video_codec/RTCDefaultVideoDecoderFactory.m
-@@ -10,76 +10,24 @@
- 
- #import "RTCDefaultVideoDecoderFactory.h"
- 
--#import "RTCH264ProfileLevelId.h"
--#import "RTCVideoDecoderH264.h"
--#import "api/video_codec/RTCVideoCodecConstants.h"
--#import "api/video_codec/RTCVideoDecoderVP8.h"
--#import "api/video_codec/RTCVideoDecoderVP9.h"
--#import "base/RTCVideoCodecInfo.h"
--
--#if defined(RTC_DAV1D_IN_INTERNAL_DECODER_FACTORY)
--#import "api/video_codec/RTCVideoDecoderAV1.h"  // nogncheck
--#endif
--
- @implementation RTC_OBJC_TYPE (RTCDefaultVideoDecoderFactory)
- 
--- (NSArray<RTC_OBJC_TYPE(RTCVideoCodecInfo) *> *)supportedCodecs {
--  NSDictionary<NSString *, NSString *> *constrainedHighParams = @{
--    @"profile-level-id" : kRTCMaxSupportedH264ProfileLevelConstrainedHigh,
--    @"level-asymmetry-allowed" : @"1",
--    @"packetization-mode" : @"1",
--  };
--  RTC_OBJC_TYPE(RTCVideoCodecInfo) *constrainedHighInfo =
--      [[RTC_OBJC_TYPE(RTCVideoCodecInfo) alloc] initWithName:kRTCVideoCodecH264Name
+@@ -16,6 +16,7 @@
+ #import "api/video_codec/RTCVideoDecoderVP8.h"
+ #import "api/video_codec/RTCVideoDecoderVP9.h"
+ #import "base/RTCVideoCodecInfo.h"
++#import "MediaCodecUtils.h"
+
+ #if defined(RTC_DAV1D_IN_INTERNAL_DECODER_FACTORY)
+ #import "api/video_codec/RTCVideoDecoderAV1.h"  // nogncheck
+@@ -31,7 +32,8 @@
+   };
+   RTC_OBJC_TYPE(RTCVideoCodecInfo) *constrainedHighInfo =
+       [[RTC_OBJC_TYPE(RTCVideoCodecInfo) alloc] initWithName:kRTCVideoCodecH264Name
 -                                                  parameters:constrainedHighParams];
--
--  NSDictionary<NSString *, NSString *> *constrainedBaselineParams = @{
--    @"profile-level-id" : kRTCMaxSupportedH264ProfileLevelConstrainedBaseline,
--    @"level-asymmetry-allowed" : @"1",
--    @"packetization-mode" : @"1",
--  };
--  RTC_OBJC_TYPE(RTCVideoCodecInfo) *constrainedBaselineInfo =
--      [[RTC_OBJC_TYPE(RTCVideoCodecInfo) alloc] initWithName:kRTCVideoCodecH264Name
++                                                  parameters:constrainedHighParams
++                                                  scalabiltyModes: H264_SCALABILITY_MODES];
+
+   NSDictionary<NSString *, NSString *> *constrainedBaselineParams = @{
+     @"profile-level-id" : kRTCMaxSupportedH264ProfileLevelConstrainedBaseline,
+@@ -40,7 +42,8 @@
+   };
+   RTC_OBJC_TYPE(RTCVideoCodecInfo) *constrainedBaselineInfo =
+       [[RTC_OBJC_TYPE(RTCVideoCodecInfo) alloc] initWithName:kRTCVideoCodecH264Name
 -                                                  parameters:constrainedBaselineParams];
-+@synthesize factory = _factory;
- 
--  RTC_OBJC_TYPE(RTCVideoCodecInfo) *vp8Info =
--      [[RTC_OBJC_TYPE(RTCVideoCodecInfo) alloc] initWithName:kRTCVideoCodecVp8Name];
--
--  NSMutableArray<RTC_OBJC_TYPE(RTCVideoCodecInfo) *> *result = [@[
--    constrainedHighInfo,
--    constrainedBaselineInfo,
--    vp8Info,
--  ] mutableCopy];
--
--  if ([RTC_OBJC_TYPE(RTCVideoDecoderVP9) isSupported]) {
--    [result
--        addObject:[[RTC_OBJC_TYPE(RTCVideoCodecInfo) alloc] initWithName:kRTCVideoCodecVp9Name]];
-+- (instancetype)init {
-+  if (self = [super init]) {
-+    _factory = [[RTC_OBJC_TYPE(RTCWrapperNativeVideoDecoderFactory) alloc]
-+        initWithTemplateFactory];
-   }
-+  return self;
-+}
- 
--#if defined(RTC_DAV1D_IN_INTERNAL_DECODER_FACTORY)
--  [result addObject:[[RTC_OBJC_TYPE(RTCVideoCodecInfo) alloc] initWithName:kRTCVideoCodecAv1Name]];
--#endif
--
--  return result;
-+- (NSArray<RTC_OBJC_TYPE(RTCVideoCodecInfo) *> *)supportedCodecs {
-+  return [_factory supportedCodecs];
- }
- 
- - (id<RTC_OBJC_TYPE(RTCVideoDecoder)>)createDecoder:(RTC_OBJC_TYPE(RTCVideoCodecInfo) *)info {
--  if ([info.name isEqualToString:kRTCVideoCodecH264Name]) {
--    return [[RTC_OBJC_TYPE(RTCVideoDecoderH264) alloc] init];
--  } else if ([info.name isEqualToString:kRTCVideoCodecVp8Name]) {
--    return [RTC_OBJC_TYPE(RTCVideoDecoderVP8) vp8Decoder];
--  } else if ([info.name isEqualToString:kRTCVideoCodecVp9Name] &&
--             [RTC_OBJC_TYPE(RTCVideoDecoderVP9) isSupported]) {
--    return [RTC_OBJC_TYPE(RTCVideoDecoderVP9) vp9Decoder];
--  }
--
--#if defined(RTC_DAV1D_IN_INTERNAL_DECODER_FACTORY)
--  if ([info.name isEqualToString:kRTCVideoCodecAv1Name]) {
--    return [RTC_OBJC_TYPE(RTCVideoDecoderAV1) av1Decoder];
--  }
--#endif
--
--  return nil;
-+  return [_factory createDecoder:info];
- }
- 
- @end
++                                                  parameters:constrainedBaselineParams
++                                                  scalabiltyModes: H264_SCALABILITY_MODES];
+
+   RTC_OBJC_TYPE(RTCVideoCodecInfo) *vp8Info =
+       [[RTC_OBJC_TYPE(RTCVideoCodecInfo) alloc] initWithName:kRTCVideoCodecVp8Name];
 diff --git a/src/sdk/objc/components/video_codec/RTCDefaultVideoEncoderFactory.h b/src/sdk/objc/components/video_codec/RTCDefaultVideoEncoderFactory.h
-index 92ab40c..e0344d0 100644
+index 92ab40c95b..e0344d0f97 100644
 --- a/src/sdk/objc/components/video_codec/RTCDefaultVideoEncoderFactory.h
 +++ b/src/sdk/objc/components/video_codec/RTCDefaultVideoEncoderFactory.h
 @@ -12,6 +12,7 @@
- 
+
  #import "RTCMacros.h"
  #import "RTCVideoEncoderFactory.h"
 +#import "api/video_codec/RTCWrappedNativeVideoEncoderFactory.h"
- 
+
  NS_ASSUME_NONNULL_BEGIN
- 
+
 @@ -23,8 +24,9 @@ RTC_OBJC_EXPORT
  @interface RTC_OBJC_TYPE (RTCDefaultVideoEncoderFactory) : NSObject <RTC_OBJC_TYPE(RTCVideoEncoderFactory)>
- 
+
  @property(nonatomic, retain) RTC_OBJC_TYPE(RTCVideoCodecInfo) *preferredCodec;
 +@property(nonatomic, strong) RTC_OBJC_TYPE(RTCWrapperNativeVideoEncoderFactory) *factory;
- 
+
 -+ (NSArray<RTC_OBJC_TYPE(RTCVideoCodecInfo) *> *)supportedCodecs;
 +- (NSArray<RTC_OBJC_TYPE(RTCVideoCodecInfo) *> *)supportedCodecs;
- 
+
  @end
- 
+
 diff --git a/src/sdk/objc/components/video_codec/RTCDefaultVideoEncoderFactory.m b/src/sdk/objc/components/video_codec/RTCDefaultVideoEncoderFactory.m
-index 8de55bd..0cd6379 100644
+index 8de55bde4a..0cd6379f73 100644
 --- a/src/sdk/objc/components/video_codec/RTCDefaultVideoEncoderFactory.m
 +++ b/src/sdk/objc/components/video_codec/RTCDefaultVideoEncoderFactory.m
 @@ -10,93 +10,31 @@
- 
+
  #import "RTCDefaultVideoEncoderFactory.h"
- 
+
 -#import "RTCH264ProfileLevelId.h"
 -#import "RTCVideoEncoderH264.h"
 -#import "api/video_codec/RTCVideoCodecConstants.h"
@@ -1077,10 +777,10 @@ index 8de55bd..0cd6379 100644
 -#endif
 -
  @implementation RTC_OBJC_TYPE (RTCDefaultVideoEncoderFactory)
- 
+
  @synthesize preferredCodec;
 +@synthesize factory = _factory;
- 
+
 -+ (NSArray<RTC_OBJC_TYPE(RTCVideoCodecInfo) *> *)supportedCodecs {
 -  NSDictionary<NSString *, NSString *> *constrainedHighParams = @{
 -    @"profile-level-id" : kRTCMaxSupportedH264ProfileLevelConstrainedHigh,
@@ -1119,7 +819,7 @@ index 8de55bd..0cd6379 100644
    }
 +  return self;
 +}
- 
+
 -#if defined(RTC_USE_LIBAOM_AV1_ENCODER)
 -  [result addObject:[[RTC_OBJC_TYPE(RTCVideoCodecInfo) alloc] initWithName:kRTCVideoCodecAv1Name]];
 -#endif
@@ -1128,7 +828,7 @@ index 8de55bd..0cd6379 100644
 +- (NSArray<RTC_OBJC_TYPE(RTCVideoCodecInfo) *> *)supportedCodecs {
 +  return [_factory supportedCodecs];
  }
- 
+
  - (id<RTC_OBJC_TYPE(RTCVideoEncoder)>)createEncoder:(RTC_OBJC_TYPE(RTCVideoCodecInfo) *)info {
 -  if ([info.name isEqualToString:kRTCVideoCodecH264Name]) {
 -    return [[RTC_OBJC_TYPE(RTCVideoEncoderH264) alloc] initWithCodecInfo:info];
@@ -1148,7 +848,7 @@ index 8de55bd..0cd6379 100644
 -  return nil;
 +  return [_factory createEncoder:info];
  }
- 
+
 -- (NSArray<RTC_OBJC_TYPE(RTCVideoCodecInfo) *> *)supportedCodecs {
 -  NSMutableArray<RTC_OBJC_TYPE(RTCVideoCodecInfo) *> *codecs =
 -      [[[self class] supportedCodecs] mutableCopy];
@@ -1167,21 +867,21 @@ index 8de55bd..0cd6379 100644
 +                 :(NSString*)scalabilityMode {
 +  return [_factory queryCodecSupport:info:scalabilityMode];
  }
- 
+
  @end
 diff --git a/src/sdk/objc/components/video_codec/RTCVideoDecoderFactoryH264.m b/src/sdk/objc/components/video_codec/RTCVideoDecoderFactoryH264.m
-index bdae19d..f38e962 100644
+index bdae19d687..f38e9624cf 100644
 --- a/src/sdk/objc/components/video_codec/RTCVideoDecoderFactoryH264.m
 +++ b/src/sdk/objc/components/video_codec/RTCVideoDecoderFactoryH264.m
 @@ -12,6 +12,7 @@
- 
+
  #import "RTCH264ProfileLevelId.h"
  #import "RTCVideoDecoderH264.h"
 +#import "MediaCodecUtils.h"
- 
+
  @implementation RTC_OBJC_TYPE (RTCVideoDecoderFactoryH264)
- 
-@@ -26,7 +27,8 @@ @implementation RTC_OBJC_TYPE (RTCVideoDecoderFactoryH264)
+
+@@ -26,7 +27,8 @@
    };
    RTC_OBJC_TYPE(RTCVideoCodecInfo) *constrainedHighInfo =
        [[RTC_OBJC_TYPE(RTCVideoCodecInfo) alloc] initWithName:codecName
@@ -1189,9 +889,9 @@ index bdae19d..f38e962 100644
 +                                                  parameters:constrainedHighParams
 +                                                  scalabiltyModes: H264_SCALABILITY_MODES];
    [codecs addObject:constrainedHighInfo];
- 
+
    NSDictionary<NSString *, NSString *> *constrainedBaselineParams = @{
-@@ -36,7 +38,8 @@ @implementation RTC_OBJC_TYPE (RTCVideoDecoderFactoryH264)
+@@ -36,7 +38,8 @@
    };
    RTC_OBJC_TYPE(RTCVideoCodecInfo) *constrainedBaselineInfo =
        [[RTC_OBJC_TYPE(RTCVideoCodecInfo) alloc] initWithName:codecName
@@ -1199,21 +899,21 @@ index bdae19d..f38e962 100644
 +                                                  parameters:constrainedBaselineParams
 +                                                  scalabiltyModes: H264_SCALABILITY_MODES];
    [codecs addObject:constrainedBaselineInfo];
- 
+
    return [codecs copy];
 diff --git a/src/sdk/objc/components/video_codec/RTCVideoEncoderFactoryH264.m b/src/sdk/objc/components/video_codec/RTCVideoEncoderFactoryH264.m
-index 9843849..33229d4 100644
+index 9843849307..33229d4598 100644
 --- a/src/sdk/objc/components/video_codec/RTCVideoEncoderFactoryH264.m
 +++ b/src/sdk/objc/components/video_codec/RTCVideoEncoderFactoryH264.m
 @@ -12,6 +12,7 @@
- 
+
  #import "RTCH264ProfileLevelId.h"
  #import "RTCVideoEncoderH264.h"
 +#import "MediaCodecUtils.h"
- 
+
  @implementation RTC_OBJC_TYPE (RTCVideoEncoderFactoryH264)
- 
-@@ -26,7 +27,8 @@ @implementation RTC_OBJC_TYPE (RTCVideoEncoderFactoryH264)
+
+@@ -26,7 +27,8 @@
    };
    RTC_OBJC_TYPE(RTCVideoCodecInfo) *constrainedHighInfo =
        [[RTC_OBJC_TYPE(RTCVideoCodecInfo) alloc] initWithName:codecName
@@ -1221,9 +921,9 @@ index 9843849..33229d4 100644
 +                                                  parameters:constrainedHighParams
 +                                                  scalabiltyModes: H264_SCALABILITY_MODES];
    [codecs addObject:constrainedHighInfo];
- 
+
    NSDictionary<NSString *, NSString *> *constrainedBaselineParams = @{
-@@ -36,7 +38,8 @@ @implementation RTC_OBJC_TYPE (RTCVideoEncoderFactoryH264)
+@@ -36,7 +38,8 @@
    };
    RTC_OBJC_TYPE(RTCVideoCodecInfo) *constrainedBaselineInfo =
        [[RTC_OBJC_TYPE(RTCVideoCodecInfo) alloc] initWithName:codecName
@@ -1231,12 +931,12 @@ index 9843849..33229d4 100644
 +                                                  parameters:constrainedBaselineParams
 +                                                  scalabiltyModes: H264_SCALABILITY_MODES];
    [codecs addObject:constrainedBaselineInfo];
- 
+
    return [codecs copy];
-@@ -46,4 +49,15 @@ @implementation RTC_OBJC_TYPE (RTCVideoEncoderFactoryH264)
+@@ -46,4 +49,15 @@
    return [[RTC_OBJC_TYPE(RTCVideoEncoderH264) alloc] initWithCodecInfo:info];
  }
- 
+
 +- (RTC_OBJC_TYPE(RTCCodecSupport*))
 +    queryCodecSupport:(RTC_OBJC_TYPE(RTCVideoCodecInfo) *)info
 +                 :(NSString*)scalabilityMode {
@@ -1249,31 +949,8 @@ index 9843849..33229d4 100644
 +}
 +
  @end
-diff --git a/src/sdk/objc/native/src/objc_video_decoder_factory.mm b/src/sdk/objc/native/src/objc_video_decoder_factory.mm
-index f9ad401..42f0023 100644
---- a/src/sdk/objc/native/src/objc_video_decoder_factory.mm
-+++ b/src/sdk/objc/native/src/objc_video_decoder_factory.mm
-@@ -19,6 +19,7 @@
- #import "sdk/objc/api/peerconnection/RTCEncodedImage+Private.h"
- #import "sdk/objc/api/peerconnection/RTCVideoCodecInfo+Private.h"
- #import "sdk/objc/api/video_codec/RTCNativeVideoDecoderBuilder+Native.h"
-+#import "sdk/objc/api/video_codec/RTCWrappedNativeVideoDecoder.h"
- #import "sdk/objc/helpers/NSString+StdString.h"
- 
- #include "api/video_codecs/sdp_video_format.h"
-@@ -94,8 +95,8 @@ int32_t RegisterDecodeCompleteCallback(DecodedImageCallback *callback) override
-     if ([codecName isEqualToString:codecInfo.name]) {
-       id<RTC_OBJC_TYPE(RTCVideoDecoder)> decoder = [decoder_factory_ createDecoder:codecInfo];
- 
--      if ([decoder conformsToProtocol:@protocol(RTC_OBJC_TYPE(RTCNativeVideoDecoderBuilder))]) {
--        return [((id<RTC_OBJC_TYPE(RTCNativeVideoDecoderBuilder)>)decoder) build:env];
-+      if ([decoder isKindOfClass:[RTC_OBJC_TYPE(RTCWrappedNativeVideoDecoder) class]]) {
-+        return [(RTC_OBJC_TYPE(RTCWrappedNativeVideoDecoder) *)decoder releaseWrappedDecoder];
-       } else {
-         return std::unique_ptr<ObjCVideoDecoder>(new ObjCVideoDecoder(decoder));
-       }
 diff --git a/src/sdk/objc/native/src/objc_video_encoder_factory.h b/src/sdk/objc/native/src/objc_video_encoder_factory.h
-index d74e493..f16d617 100644
+index d74e4933d2..f16d617537 100644
 --- a/src/sdk/objc/native/src/objc_video_encoder_factory.h
 +++ b/src/sdk/objc/native/src/objc_video_encoder_factory.h
 @@ -35,6 +35,9 @@ class ObjCVideoEncoderFactory : public VideoEncoderFactory {
@@ -1283,17 +960,17 @@ index d74e493..f16d617 100644
 +  VideoEncoderFactory::CodecSupport QueryCodecSupport(
 +      const SdpVideoFormat& format,
 +      absl::optional<std::string> scalability_mode) const override;
- 
+
   private:
    id<RTC_OBJC_TYPE(RTCVideoEncoderFactory)> encoder_factory_;
 diff --git a/src/sdk/objc/native/src/objc_video_encoder_factory.mm b/src/sdk/objc/native/src/objc_video_encoder_factory.mm
-index 1085cb8..44948b7 100644
+index 1085cb8cb4..44948b70f3 100644
 --- a/src/sdk/objc/native/src/objc_video_encoder_factory.mm
 +++ b/src/sdk/objc/native/src/objc_video_encoder_factory.mm
-@@ -207,4 +207,23 @@ void OnCurrentEncoder(const SdpVideoFormat &format) override {
+@@ -207,4 +207,23 @@ std::unique_ptr<VideoEncoderFactory::EncoderSelectorInterface>
    return nullptr;
  }
- 
+
 +VideoEncoderFactory::CodecSupport ObjCVideoEncoderFactory::QueryCodecSupport(
 +    const SdpVideoFormat& format,
 +    absl::optional<std::string> scalability_mode) const {
@@ -1314,27 +991,12 @@ index 1085cb8..44948b7 100644
 +}
 +
  }  // namespace webrtc
-diff --git a/src/sdk/objc/unittests/objc_video_decoder_factory_tests.mm b/src/sdk/objc/unittests/objc_video_decoder_factory_tests.mm
-index 33c5089..4b56bbc 100644
---- a/src/sdk/objc/unittests/objc_video_decoder_factory_tests.mm
-+++ b/src/sdk/objc/unittests/objc_video_decoder_factory_tests.mm
-@@ -35,7 +35,9 @@
- 
-   id decoderFactoryMock = OCMProtocolMock(@protocol(RTC_OBJC_TYPE(RTCVideoDecoderFactory)));
-   RTC_OBJC_TYPE(RTCVideoCodecInfo)* supported =
--      [[RTC_OBJC_TYPE(RTCVideoCodecInfo) alloc] initWithName:@"H264" parameters:nil];
-+      [[RTC_OBJC_TYPE(RTCVideoCodecInfo) alloc] initWithName:@"H264"
-+                                                  parameters:nil
-+                                             scalabiltyModes:nil];
-   OCMStub([decoderFactoryMock supportedCodecs]).andReturn(@[ supported ]);
-   OCMStub([decoderFactoryMock createDecoder:[OCMArg any]]).andReturn(decoderMock);
-   return decoderFactoryMock;
 diff --git a/src/sdk/objc/unittests/objc_video_encoder_factory_tests.mm b/src/sdk/objc/unittests/objc_video_encoder_factory_tests.mm
-index a04e797..60eee24 100644
+index a04e797672..60eee24095 100644
 --- a/src/sdk/objc/unittests/objc_video_encoder_factory_tests.mm
 +++ b/src/sdk/objc/unittests/objc_video_encoder_factory_tests.mm
-@@ -37,7 +37,9 @@
- 
+@@ -37,7 +37,9 @@ id<RTC_OBJC_TYPE(RTCVideoEncoderFactory)> CreateEncoderFactoryReturning(int retu
+
    id encoderFactoryMock = OCMProtocolMock(@protocol(RTC_OBJC_TYPE(RTCVideoEncoderFactory)));
    RTC_OBJC_TYPE(RTCVideoCodecInfo)* supported =
 -      [[RTC_OBJC_TYPE(RTCVideoCodecInfo) alloc] initWithName:@"H264" parameters:nil];


### PR DESCRIPTION
## Synopsis

Right now `enable_ios_scalability_mode.patch` breaks `RTCDefaultVideoEncoderFactory` so it fails to encode any video other then h264.

## Solution

Rework `RTCWrappedNativeVideoEncoder` so it would `conformsToProtocol:@protocol(RTC_OBJC_TYPE(RTCNativeVideoEncoderBuilder))` ensuring correct `webrtc::Environment` injection.

