### PR TITLE
Fix wrong include of `PROXY_TRACE_EVENTS` related header file

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: ["main", "fix-trace-events"]
+    branches: ["main"]
     tags: ["*"]
   pull_request:
     branches: ["main"]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: ["main"]
+    branches: ["main", "fix-trace-events"]
     tags: ["*"]
   pull_request:
     branches: ["main"]

--- a/VERSION
+++ b/VERSION
@@ -12,7 +12,7 @@ WEBRTC_COMMIT=9e5db68b15087eccd8d2493b4e8539c1657e0f75
 # Required for being able to release new versions without waiting for the
 # `WEBRTC_VERSION` bump. If absent or is commented out, then no `REVISION` is
 # added to the `WEBRTC_VERSION`.
-#REVISION=1
+REVISION=1
 
 PACKAGE_NAMES= \
   linux-arm64 \

--- a/build.windows.ps1
+++ b/build.windows.ps1
@@ -117,6 +117,8 @@ if (!(Test-Path $BUILD_DIR)) {
   New-Item $BUILD_DIR -ItemType Directory -Force
 }
 
+Write-Output "Applying fix_disable_proxy_trace_events.patch"
+Exec { git apply -p1 --ignore-space-change -v $PATCH_DIR\fix_disable_proxy_trace_events.patch }
 Push-Location $WEBRTC_DIR\src
   Exec { gclient sync --with_branch_heads -r $WEBRTC_COMMIT }
   Write-Output "Start to apply patches..."
@@ -124,8 +126,6 @@ Push-Location $WEBRTC_DIR\src
   Exec { git apply -p1 --ignore-space-change --ignore-whitespace --whitespace=nowarn --reject -v $PATCH_DIR\add_licenses.patch }
   Write-Output "Applying 4k.patch"
   Exec { git apply -p1 --ignore-space-change --ignore-whitespace --whitespace=nowarn --reject -v $PATCH_DIR\4k.patch }
-  Write-Output "Applying fix_disable_proxy_trace_events.patch"
-  Exec { git apply -p1 --ignore-space-change -v $PATCH_DIR\fix_disable_proxy_trace_events.patch }
   Write-Output "Applying windows_fix_optional.patch"
   Exec { git apply -p1 --ignore-space-change --ignore-whitespace --whitespace=nowarn --reject -v $PATCH_DIR\windows_fix_optional.patch }
   Write-Output "Applying windows_add_deps.patch"

--- a/build.windows.ps1
+++ b/build.windows.ps1
@@ -117,8 +117,6 @@ if (!(Test-Path $BUILD_DIR)) {
   New-Item $BUILD_DIR -ItemType Directory -Force
 }
 
-Write-Output "Applying fix_disable_proxy_trace_events.patch"
-Exec { git apply -p1 --ignore-space-change -v $PATCH_DIR\fix_disable_proxy_trace_events.patch }
 Push-Location $WEBRTC_DIR\src
   Exec { gclient sync --with_branch_heads -r $WEBRTC_COMMIT }
   Write-Output "Start to apply patches..."
@@ -132,6 +130,8 @@ Push-Location $WEBRTC_DIR\src
   Exec { git apply -p1 --ignore-space-change --ignore-whitespace --whitespace=nowarn --reject -v $PATCH_DIR\windows_add_deps.patch }
   Write-Output "All patches are applied"
 Pop-Location
+Write-Output "Applying fix_disable_proxy_trace_events.patch"
+Exec { git apply -p1 --ignore-space-change --ignore-whitespace --whitespace=nowarn --reject -v $PATCH_DIR\fix_disable_proxy_trace_events.patch }
 Pop-Location
 
 Get-PSDrive

--- a/build.windows.ps1
+++ b/build.windows.ps1
@@ -124,6 +124,8 @@ Push-Location $WEBRTC_DIR\src
   Exec { git apply -p1 --ignore-space-change --ignore-whitespace --whitespace=nowarn --reject -v $PATCH_DIR\add_licenses.patch }
   Write-Output "Applying 4k.patch"
   Exec { git apply -p1 --ignore-space-change --ignore-whitespace --whitespace=nowarn --reject -v $PATCH_DIR\4k.patch }
+  Write-Output "Applying fix_disable_proxy_trace_events.patch"
+  Exec { git apply -p1 --ignore-space-change -v $PATCH_DIR\fix_disable_proxy_trace_events.patch }
   Write-Output "Applying windows_fix_optional.patch"
   Exec { git apply -p1 --ignore-space-change --ignore-whitespace --whitespace=nowarn --reject -v $PATCH_DIR\windows_fix_optional.patch }
   Write-Output "Applying windows_add_deps.patch"

--- a/build.windows.ps1
+++ b/build.windows.ps1
@@ -128,10 +128,10 @@ Push-Location $WEBRTC_DIR\src
   Exec { git apply -p1 --ignore-space-change --ignore-whitespace --whitespace=nowarn --reject -v $PATCH_DIR\windows_fix_optional.patch }
   Write-Output "Applying windows_add_deps.patch"
   Exec { git apply -p1 --ignore-space-change --ignore-whitespace --whitespace=nowarn --reject -v $PATCH_DIR\windows_add_deps.patch }
-  Write-Output "All patches are applied"
 Pop-Location
 Write-Output "Applying fix_disable_proxy_trace_events.patch"
 Exec { git apply -p1 --ignore-space-change --ignore-whitespace --whitespace=nowarn --reject -v $PATCH_DIR\fix_disable_proxy_trace_events.patch }
+Write-Output "All patches are applied"
 Pop-Location
 
 Get-PSDrive


### PR DESCRIPTION
Current libwebrtc release is broken on Windows, because `perfetto/protozero/message_handle.h` include is not getting resolved, because we disabled this feature flag. This is bug in libwebrtc, that they're not hiding this unneeded include when `RTC_DISABLE_PROXY_TRACE_EVENTS` flag is enabled.

This MR just reenables applying of this patch on Windows.